### PR TITLE
I think I got it

### DIFF
--- a/INFO.yaml
+++ b/INFO.yaml
@@ -13,7 +13,7 @@ project_lead: &opnfv_releng_ptl
 primary_contact: *opnfv_releng_ptl
 issue_tracking:
     type: 'iiia'
-    url: ''
+    url: 'ya'
     key: ''
 mailing_list:
     type: ''


### PR DESCRIPTION
GitHub hook trigger for GITScm polling needed to be checked to create
the
https://jenkins-proxy.int.linuxfoundation.org/sandbox/github-webhook/
(push)

and I thnk for the pull request builders
the url you need is the base url
https://jenkins-proxy.int.linuxfoundation.org/sandbox/

Signed-off-by: Aric Gardner <agardner@linuxfoundation.org>